### PR TITLE
chore: handle manual tags in CD

### DIFF
--- a/.github/workflows/tag-release.yaml
+++ b/.github/workflows/tag-release.yaml
@@ -3,6 +3,8 @@ on:
   push:
     branches:
     - main
+    tags:
+    - v*
 jobs:
   tag:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Allow releases to be triggered by manually pushing tags too.
