### PR TITLE
Fix release naming and uploading

### DIFF
--- a/.github/workflows/release-tag.yaml
+++ b/.github/workflows/release-tag.yaml
@@ -4,7 +4,7 @@ on:
     tags:
     - v*
 jobs:
-  tag:
+  release:
     strategy:
       # avoid concurrent goreleaser runs
       max-parallel: 1

--- a/.goreleaser.macos-latest.yml
+++ b/.goreleaser.macos-latest.yml
@@ -2,3 +2,5 @@ builds:
 - dir: cmd/piv-agent
   goos:
   - darwin
+checksum:
+  name_template: "{{ .ProjectName }}_{{ .Version }}_darwin_checksums.txt"

--- a/.goreleaser.ubuntu-latest.yml
+++ b/.goreleaser.ubuntu-latest.yml
@@ -4,3 +4,5 @@ builds:
   - linux
   goarch:
   - amd64
+checksum:
+  name_template: "{{ .ProjectName }}_{{ .Version }}_linux_checksums.txt"


### PR DESCRIPTION
Avoid conflicting checksum names between linux and macos goreleaser runs.