### PR TITLE
chore: avoid trying to release for macOS

### DIFF
--- a/.github/workflows/tag-and-release.yaml
+++ b/.github/workflows/tag-and-release.yaml
@@ -42,7 +42,6 @@ jobs:
       matrix:
         os:
         - ubuntu-latest
-        - macos-latest
     runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout


### PR DESCRIPTION
It is not currently a supported platform.


