### PR TITLE
Implement concurrency in GPG agent server

### DIFF
--- a/deploy/piv-agent.service
+++ b/deploy/piv-agent.service
@@ -2,4 +2,4 @@
 Description=piv-agent service
 
 [Service]
-ExecStart=piv-agent serve --debug --agent-types=ssh=0;gpg=1
+ExecStart=piv-agent serve --agent-types=ssh=0;gpg=1

--- a/internal/assuan/assuan_test.go
+++ b/internal/assuan/assuan_test.go
@@ -2,6 +2,7 @@ package assuan_test
 
 import (
 	"bytes"
+	"context"
 	"crypto"
 	"crypto/ecdsa"
 	"encoding/hex"
@@ -153,7 +154,7 @@ func TestSign(t *testing.T) {
 				}
 			}
 			// start the state machine
-			if err := a.Run(); err != nil {
+			if err := a.Run(context.Background()); err != nil {
 				tt.Fatal(err)
 			}
 			// check the responses
@@ -226,7 +227,7 @@ func TestKeyinfo(t *testing.T) {
 				}
 			}
 			// start the state machine
-			if err := a.Run(); err != nil {
+			if err := a.Run(context.Background()); err != nil {
 				tt.Fatal(err)
 			}
 			// check the responses
@@ -349,7 +350,7 @@ func TestDecryptRSAKeyfile(t *testing.T) {
 				}
 			}
 			// start the state machine
-			if err := a.Run(); err != nil {
+			if err := a.Run(context.Background()); err != nil {
 				tt.Fatal(err)
 			}
 			// check the responses
@@ -447,7 +448,7 @@ func TestSignRSAKeyfile(t *testing.T) {
 				}
 			}
 			// start the state machine
-			if err := a.Run(); err != nil {
+			if err := a.Run(context.Background()); err != nil {
 				tt.Fatal(err)
 			}
 			// check the responses
@@ -533,7 +534,7 @@ func TestReadKey(t *testing.T) {
 				}
 			}
 			// start the state machine
-			if err := a.Run(); err != nil {
+			if err := a.Run(context.Background()); err != nil {
 				tt.Fatal(err)
 			}
 			// check the responses

--- a/internal/server/ssh.go
+++ b/internal/server/ssh.go
@@ -42,7 +42,7 @@ func (s *SSH) Serve(ctx context.Context, a *ssh.Agent, l net.Listener,
 			s.log.Debug("start serving SSH connection")
 			if err := agent.ServeAgent(a, conn); err != nil {
 				if errors.Is(err, io.EOF) {
-					s.log.Debug("finish serving connection")
+					s.log.Debug("finish serving SSH connection")
 					continue
 				}
 				return fmt.Errorf("ssh Serve error: %w", err)


### PR DESCRIPTION
Allow piv-agent to serve multiple gpg-agent connections concurrently.

Closes: #57 