### PR TITLE
Lazy decryption for keyfiles

### DIFF
--- a/internal/assuan/assuan.go
+++ b/internal/assuan/assuan.go
@@ -77,8 +77,8 @@ func New(rw io.ReadWriter, log *zap.Logger, ks ...KeyService) *Assuan {
 					}
 					keyFound, _, err = haveKey(ks, keygrips)
 					if err != nil {
-						_, _ = io.WriteString(rw, "ERR 1 couldn't check for keygrip\n")
-						return fmt.Errorf("couldn't check keygrips: %v", err)
+						_, err = io.WriteString(rw, "ERR 1 couldn't check for keygrip\n")
+						return err
 					}
 					if keyFound {
 						_, err = io.WriteString(rw, "OK\n")

--- a/internal/keyservice/gpg/havekey.go
+++ b/internal/keyservice/gpg/havekey.go
@@ -1,0 +1,41 @@
+package gpg
+
+import (
+	"bytes"
+	"crypto/ecdsa"
+	"crypto/rsa"
+)
+
+// HaveKey takes a list of keygrips, and returns a boolean indicating if any of
+// the given keygrips were found, the found keygrip, and an error, if any.
+func (g *KeyService) HaveKey(keygrips [][]byte) (bool, []byte, error) {
+	for _, keyfile := range g.privKeys {
+		for _, privKey := range keyfile.keys {
+			pubKeyRSA, ok := privKey.PublicKey.PublicKey.(*rsa.PublicKey)
+			if ok {
+				for _, kg := range keygrips {
+					rsaKG, err := keygripRSA(pubKeyRSA)
+					if err != nil {
+						return false, nil, err
+					}
+					if bytes.Equal(kg, rsaKG) {
+						return true, kg, nil
+					}
+				}
+			}
+			pubKeyECDSA, ok := privKey.PublicKey.PublicKey.(*ecdsa.PublicKey)
+			if ok {
+				for _, kg := range keygrips {
+					ecdsaKG, err := KeygripECDSA(pubKeyECDSA)
+					if err != nil {
+						return false, nil, err
+					}
+					if bytes.Equal(kg, ecdsaKG) {
+						return true, kg, nil
+					}
+				}
+			}
+		}
+	}
+	return false, nil, nil
+}

--- a/internal/keyservice/gpg/keygrip.go
+++ b/internal/keyservice/gpg/keygrip.go
@@ -88,9 +88,12 @@ func compute(parts []part) ([]byte, error) {
 }
 
 // keygripRSA calculates a keygrip for an RSA public key.
-func keygripRSA(pubKey *rsa.PublicKey) []byte {
+func keygripRSA(pubKey *rsa.PublicKey) ([]byte, error) {
+	if pubKey == nil {
+		return nil, fmt.Errorf("nil key")
+	}
 	keygrip := sha1.New()
 	keygrip.Write([]byte{0})
 	keygrip.Write(pubKey.N.Bytes())
-	return keygrip.Sum(nil)
+	return keygrip.Sum(nil), nil
 }


### PR DESCRIPTION
When performing signing for a given key, gpg will interrogate the
gpg-agent for availability of keygrips of _all_ signing keys, not just
the one that ends up being used for the actual signing.

piv-agent used to pre-emptively decrypted the keyfiles when checking
them against the supplied keygrip. This change causes it to wait until
the actual point of signature before decrypting the keyfiles.

This means that you avoid a pinentry prompt for keyfiles when signing
using a hardware security device.

This change also makes a couple of error handling changes to make
piv-agent more robust when cancelling or failing pinentry prompts.

Closes: #58 
