### PR TITLE
Clean up connections

### DIFF
--- a/cmd/piv-agent/serve.go
+++ b/cmd/piv-agent/serve.go
@@ -50,6 +50,7 @@ func (cmd *ServeCmd) Run(log *zap.Logger) error {
 	log.Info("startup", zap.String("version", version),
 		zap.String("build date", date))
 	p := piv.New(log)
+	defer p.CloseAll()
 	// use FDs passed via socket activation
 	ls, err := sockets.Get(validAgents)
 	if err != nil {

--- a/cmd/piv-agent/serve.go
+++ b/cmd/piv-agent/serve.go
@@ -73,6 +73,11 @@ func (cmd *ServeCmd) Run(log *zap.Logger) error {
 			s := server.NewSSH(log)
 			a := ssh.NewAgent(p, log, cmd.LoadKeyfile)
 			err := s.Serve(ctx, a, ls[cmd.AgentTypes["ssh"]], idle, cmd.IdleTimeout)
+			if err != nil {
+				log.Debug("exiting SSH server", zap.Error(err))
+			} else {
+				log.Debug("exiting SSH server successfully")
+			}
 			cancel()
 			return err
 		})

--- a/internal/keyservice/piv/keyservice.go
+++ b/internal/keyservice/piv/keyservice.go
@@ -138,3 +138,11 @@ func (p *KeyService) GetDecrypter(keygrip []byte) (crypto.Decrypter, error) {
 	}
 	return &ECDHKey{ecdsa: ecdsaPrivKey}, nil
 }
+
+// CloseAll closes all security keys without checking for errors.
+// This should be called to clean up connections to `pcscd`.
+func (p *KeyService) CloseAll() {
+	for _, k := range p.securityKeys {
+		_ = k.Close()
+	}
+}

--- a/internal/keyservice/piv/keyservice.go
+++ b/internal/keyservice/piv/keyservice.go
@@ -142,7 +142,10 @@ func (p *KeyService) GetDecrypter(keygrip []byte) (crypto.Decrypter, error) {
 // CloseAll closes all security keys without checking for errors.
 // This should be called to clean up connections to `pcscd`.
 func (p *KeyService) CloseAll() {
+	p.log.Debug("closing security keys", zap.Int("count", len(p.securityKeys)))
 	for _, k := range p.securityKeys {
-		_ = k.Close()
+		if err := k.Close(); err != nil {
+			p.log.Debug("couldn't close key", zap.Error(err))
+		}
 	}
 }


### PR DESCRIPTION
Previously `piv-agent` would sometimes get into a state where an exclusive connection to the card blocked access
```
{"card": "Yubico YubiKey FIDO+CCID 01 00", "error": "couldn't open card \"Yubico YubiKey FIDO+CCID 01 00\": connecting to smart card: the smart card cannot be accessed because of other connections outstanding"}
```
This seemed to happen after an idle timeout and restart.

According to the [pcsc-lite documentation](https://pcsclite.apdu.fr/api/group__API.html#ga6aabcba7744c5c9419fdd6404f73a934) the context should always be released. So this PR makes sure to do so in `ServeCmd.Run()`.