### PR TITLE
chore: upgrade golangci-lint action version

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -9,8 +9,12 @@ jobs:
       uses: actions/checkout@v2
     - name: Install Dependencies
       run: sudo apt-get update && sudo apt-get -u install libpcsclite-dev
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: "^1.17"
     - name: golangci-lint
-      uses: golangci/golangci-lint-action@v2.5.2
+      uses: golangci/golangci-lint-action@v3
       with:
         version: latest
   commitlint:


### PR DESCRIPTION
The new version requires an explicit setup-go step.

<!--
IMPORTANT NOTE: Commits must adhere to the conventional commits specification:
https://www.conventionalcommits.org/en/v1.0.0/

Explain the **details** for making this change. What existing problem does the pull request solve?

Put `Closes: #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
-->
