### PR TITLE
feat: implement dropping all identities from the agent

### DIFF
--- a/cmd/piv-agent/serve.go
+++ b/cmd/piv-agent/serve.go
@@ -71,7 +71,7 @@ func (cmd *ServeCmd) Run(log *zap.Logger) error {
 		log.Debug("starting SSH server")
 		g.Go(func() error {
 			s := server.NewSSH(log)
-			a := ssh.NewAgent(p, log, cmd.LoadKeyfile)
+			a := ssh.NewAgent(p, log, cmd.LoadKeyfile, cancel)
 			err := s.Serve(ctx, a, ls[cmd.AgentTypes["ssh"]], idle, cmd.IdleTimeout)
 			if err != nil {
 				log.Debug("exiting SSH server", zap.Error(err))


### PR DESCRIPTION
In piv-agent this is done by simply exiting, since the agent will be
restarted when required due to socket activation.

This also means that the persistent transaction taken by the agent will be dropped.

Call this from the command-line via `ssh-add -D`.

Idea taken from https://github.com/FiloSottile/yubikey-agent/pull/121
