### PR TITLE
chore: unpin hugo version to rely on latest

### DIFF
--- a/.github/workflows/user-documentation.yaml
+++ b/.github/workflows/user-documentation.yaml
@@ -24,7 +24,6 @@ jobs:
     - name: Setup Hugo
       uses: peaceiris/actions-hugo@v2
       with:
-        hugo-version: '0.87.0'
         extended: true
 
     - name: Setup Node


### PR DESCRIPTION
We aren't doing anyting fancy. Latest will be fine.

<!--
IMPORTANT NOTE: Commits must adhere to the conventional commits specification:
https://www.conventionalcommits.org/en/v1.0.0/

Explain the **details** for making this change. What existing problem does the pull request solve?

Put `Closes: #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
-->
