### PR TITLE
feat: multiple decrypt slots for multiple touch policies

### DIFF
--- a/cmd/piv-agent/setup.go
+++ b/cmd/piv-agent/setup.go
@@ -16,8 +16,8 @@ type SetupCmd struct {
 	Card             string   `kong:"help='Specify a smart card device'"`
 	ResetSecurityKey bool     `kong:"help='Overwrite any existing keys'"`
 	PIN              uint64   `kong:"help='Set the PIN/PUK of the device (6-8 digits). Will be prompted interactively if not provided.'"`
-	SigningKeys      []string `kong:"default='cached,always,never',enum='cached,always,never',help='Generate signing keys with various touch policies (cached,always,never)'"`
-	DecryptingKey    bool     `kong:"default='true',help='Generate a decrypting key (default true)'"`
+	SigningKeys      []string `kong:"default='cached,always,never',enum='cached,always,never',help='Generate signing keys with various touch policies (default cached,always,never)'"`
+	DecryptingKeys   []string `kong:"default='cached,always,never',enum='cached,always,never',help='Generate a decrypting key (default cached,always,never)'"`
 }
 
 func interactivePIN() (uint64, error) {
@@ -61,7 +61,7 @@ func (cmd *SetupCmd) Run() error {
 		return fmt.Errorf("couldn't get security key: %v", err)
 	}
 	err = k.Setup(strconv.FormatUint(cmd.PIN, 10), version,
-		cmd.ResetSecurityKey, cmd.SigningKeys, cmd.DecryptingKey)
+		cmd.ResetSecurityKey, cmd.SigningKeys, cmd.DecryptingKeys)
 	if errors.Is(err, securitykey.ErrKeySetUp) {
 		return fmt.Errorf("--reset-security-key not specified: %w", err)
 	}

--- a/cmd/piv-agent/setupslots.go
+++ b/cmd/piv-agent/setupslots.go
@@ -10,11 +10,11 @@ import (
 
 // SetupSlotsCmd represents the setup command.
 type SetupSlotsCmd struct {
-	Card          string   `kong:"help='Specify a smart card device'"`
-	ResetSlots    bool     `kong:"help='Overwrite existing keys in the targeted slots'"`
-	PIN           uint64   `kong:"help='The PIN/PUK of the device (6-8 digits). Will be prompted interactively if not provided.'"`
-	SigningKeys   []string `kong:"required,enum='cached,always,never',help='Set up slots for signing keys with various touch policies (possible values cached,always,never)'"`
-	DecryptingKey bool     `kong:"default='false',help='Set up slot for a decrypting key (default false)'"`
+	Card           string   `kong:"help='Specify a smart card device'"`
+	ResetSlots     bool     `kong:"help='Overwrite existing keys in the targeted slots'"`
+	PIN            uint64   `kong:"help='The PIN/PUK of the device (6-8 digits). Will be prompted interactively if not provided.'"`
+	SigningKeys    []string `kong:"required,enum='cached,always,never',help='Set up slots for signing keys with various touch policies (possible values cached,always,never)'"`
+	DecryptingKeys []string `kong:"required,enum='cached,always,never',help='Set up slot for a decrypting key (possible values cached,always,never)'"`
 }
 
 // Run the setup-slot command to configure a slot on a security key.
@@ -35,7 +35,7 @@ func (cmd *SetupSlotsCmd) Run() error {
 		return fmt.Errorf("couldn't get security key: %v", err)
 	}
 	err = k.SetupSlots(strconv.FormatUint(cmd.PIN, 10), version, cmd.ResetSlots,
-		cmd.SigningKeys, cmd.DecryptingKey)
+		cmd.SigningKeys, cmd.DecryptingKeys)
 	if errors.Is(err, securitykey.ErrKeySetUp) {
 		return fmt.Errorf("--reset-slots not specified: %w", err)
 	}

--- a/internal/securitykey/setupslots.go
+++ b/internal/securitykey/setupslots.go
@@ -5,10 +5,10 @@ import "fmt"
 // SetupSlots configures slots on the security key without resetting it
 // completely.
 func (k *SecurityKey) SetupSlots(pin, version string, reset bool,
-	signingKeys []string, decryptingKey bool) error {
+	signingKeys []string, decryptingKeys []string) error {
 	var err error
 	if !reset {
-		setUp, err := k.checkSlotsSetUp(signingKeys, decryptingKey)
+		setUp, err := k.checkSlotsSetUp(signingKeys, decryptingKeys)
 		if err != nil {
 			return fmt.Errorf("couldn't check slots: %v", err)
 		}
@@ -31,12 +31,12 @@ func (k *SecurityKey) SetupSlots(pin, version string, reset bool,
 		}
 	}
 	// setup decrypt key
-	if decryptingKey {
-		err := k.configureSlot(*metadata.ManagementKey,
-			defaultDecryptSlots["never"], version)
+	for _, p := range decryptingKeys {
+		err := k.configureSlot(*metadata.ManagementKey, defaultDecryptSlots[p],
+			version)
 		if err != nil {
 			return fmt.Errorf("couldn't configure slot %v: %v",
-				defaultDecryptSlots["cached"], err)
+				defaultDecryptSlots[p], err)
 		}
 	}
 	return nil

--- a/internal/securitykey/slotspec.go
+++ b/internal/securitykey/slotspec.go
@@ -35,8 +35,12 @@ var defaultSignSlots = map[string]SlotSpec{
 	"never": {piv.SlotCardAuthentication, piv.TouchPolicyNever},
 }
 
+var alwaysDecryptSlot, _ = piv.RetiredKeyManagementSlot(0x82)
+var neverDecryptSlot, _ = piv.RetiredKeyManagementSlot(0x83)
+
 // defaultDecryptSlots represents the slot specifications for decrypting
-// operations.
+// operations. By using additional "retired" slots we can enable multiple touch
+// policies for decrypt.
 var defaultDecryptSlots = map[string]SlotSpec{
 	// Slot 9d: Key Management
 	// This certificate and its associated private key is used for encryption for
@@ -45,5 +49,9 @@ var defaultDecryptSlots = map[string]SlotSpec{
 	// private key operations. Once the PIN has been provided successfully,
 	// multiple private key operations may be performed without additional
 	// cardholder consent.
-	"never": {piv.SlotKeyManagement, piv.TouchPolicyNever},
+	"cached": {piv.SlotKeyManagement, piv.TouchPolicyCached},
+	// "Retired" key management slot with an "always" touch policy.
+	"always": {alwaysDecryptSlot, piv.TouchPolicyAlways},
+	// "Retired" key management slot with a "never" touch policy.
+	"never": {neverDecryptSlot, piv.TouchPolicyNever},
 }


### PR DESCRIPTION
Set up additional key slots for decrypt purposes.

Before we only set up a decrypt slot with touch policy "never".

Now we set up decrypt slots with touch policy "never", "always", and "cached".

These are separate from the signing slots (which are shared by SSH/GPG). So now `piv-agent` uses six slots by default.
