### PR TITLE
Add configuration options to the serve command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/piv-agent

--- a/cmd/piv-agent/list.go
+++ b/cmd/piv-agent/list.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/smlx/piv-agent/internal/keyservice/piv"
+	"github.com/smlx/piv-agent/internal/pinentry"
 	"go.uber.org/zap"
 )
 
@@ -17,7 +18,7 @@ type ListCmd struct {
 
 // Run the list command.
 func (cmd *ListCmd) Run(l *zap.Logger) error {
-	p := piv.New(l)
+	p := piv.New(l, pinentry.New("pinentry"))
 	securityKeys, err := p.SecurityKeys()
 	if err != nil {
 		return fmt.Errorf("couldn't get security keys: %w", err)

--- a/cmd/piv-agent/main.go
+++ b/cmd/piv-agent/main.go
@@ -1,3 +1,4 @@
+// Package main implements the piv-agent CLI.
 package main
 
 import (

--- a/cmd/piv-agent/serve.go
+++ b/cmd/piv-agent/serve.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/smlx/piv-agent/internal/keyservice/piv"
+	"github.com/smlx/piv-agent/internal/notify"
 	"github.com/smlx/piv-agent/internal/pinentry"
 	"github.com/smlx/piv-agent/internal/server"
 	"github.com/smlx/piv-agent/internal/sockets"
@@ -20,10 +21,11 @@ type agentTypeFlag map[string]uint
 
 // ServeCmd represents the listen command.
 type ServeCmd struct {
-	LoadKeyfile bool          `kong:"default=true,help='Load the key file from ~/.ssh/id_ed25519'"`
-	ExitTimeout time.Duration `kong:"default=12h,help='Exit after this period to drop transaction and key file passphrase cache, even if service is in use'"`
-	IdleTimeout time.Duration `kong:"default=32m,help='Exit after this period of disuse'"`
-	AgentTypes  agentTypeFlag `kong:"default='ssh=0;gpg=1',help='Agent types to handle'"`
+	LoadKeyfile      bool          `kong:"default=true,help='Load the key file from ~/.ssh/id_ed25519'"`
+	ExitTimeout      time.Duration `kong:"default=12h,help='Exit after this period to drop transaction and key file passphrase cache, even if service is in use'"`
+	IdleTimeout      time.Duration `kong:"default=32m,help='Exit after this period of disuse'"`
+	TouchNotifyDelay time.Duration `kong:"default=6s,help='Display a notification after this period when waiting for a touch'"`
+	AgentTypes       agentTypeFlag `kong:"default='ssh=0;gpg=1',help='Agent types to handle'"`
 }
 
 // validAgents is the list of agents supported by piv-agent.
@@ -65,13 +67,14 @@ func (cmd *ServeCmd) Run(log *zap.Logger) error {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	idle := time.NewTicker(cmd.IdleTimeout)
+	n := notify.New(log, cmd.TouchNotifyDelay)
 	g := errgroup.Group{}
 	// start SSH agent if given in agent-type flag
 	if _, ok := cmd.AgentTypes["ssh"]; ok {
 		log.Debug("starting SSH server")
 		g.Go(func() error {
 			s := server.NewSSH(log)
-			a := ssh.NewAgent(p, log, cmd.LoadKeyfile, cancel)
+			a := ssh.NewAgent(p, log, cmd.LoadKeyfile, n, cancel)
 			err := s.Serve(ctx, a, ls[cmd.AgentTypes["ssh"]], idle, cmd.IdleTimeout)
 			if err != nil {
 				log.Debug("exiting SSH server", zap.Error(err))
@@ -91,7 +94,7 @@ func (cmd *ServeCmd) Run(log *zap.Logger) error {
 	if _, ok := cmd.AgentTypes["gpg"]; ok {
 		log.Debug("starting GPG server")
 		g.Go(func() error {
-			s := server.NewGPG(p, &pinentry.PINEntry{}, log, fallbackKeys)
+			s := server.NewGPG(p, &pinentry.PINEntry{}, log, fallbackKeys, n)
 			err := s.Serve(ctx, ls[cmd.AgentTypes["gpg"]], idle, cmd.IdleTimeout)
 			if err != nil {
 				log.Debug("exiting GPG server", zap.Error(err))

--- a/cmd/piv-agent/serve.go
+++ b/cmd/piv-agent/serve.go
@@ -21,11 +21,12 @@ type agentTypeFlag map[string]uint
 
 // ServeCmd represents the listen command.
 type ServeCmd struct {
-	LoadKeyfile      bool          `kong:"default=true,help='Load the key file from ~/.ssh/id_ed25519'"`
-	ExitTimeout      time.Duration `kong:"default=12h,help='Exit after this period to drop transaction and key file passphrase cache, even if service is in use'"`
-	IdleTimeout      time.Duration `kong:"default=32m,help='Exit after this period of disuse'"`
-	TouchNotifyDelay time.Duration `kong:"default=6s,help='Display a notification after this period when waiting for a touch'"`
-	AgentTypes       agentTypeFlag `kong:"default='ssh=0;gpg=1',help='Agent types to handle'"`
+	LoadKeyfile        bool          `kong:"default=true,help='Load the key file from ~/.ssh/id_ed25519'"`
+	ExitTimeout        time.Duration `kong:"default=12h,help='Exit after this period to drop transaction and key file passphrase cache, even if service is in use'"`
+	IdleTimeout        time.Duration `kong:"default=32m,help='Exit after this period of disuse'"`
+	TouchNotifyDelay   time.Duration `kong:"default=6s,help='Display a notification after this period when waiting for a touch'"`
+	PinentryBinaryName string        `kong:"default='pinentry',help='Pinentry binary which will be used, must be in $PATH'"`
+	AgentTypes         agentTypeFlag `kong:"default='ssh=0;gpg=1',help='Agent types to handle'"`
 }
 
 // validAgents is the list of agents supported by piv-agent.
@@ -51,7 +52,8 @@ func (flagAgents *agentTypeFlag) AfterApply() error {
 func (cmd *ServeCmd) Run(log *zap.Logger) error {
 	log.Info("startup", zap.String("version", version),
 		zap.String("build date", date))
-	p := piv.New(log)
+	pe := pinentry.New(cmd.PinentryBinaryName)
+	p := piv.New(log, pe)
 	defer p.CloseAll()
 	// use FDs passed via socket activation
 	ls, err := sockets.Get(validAgents)
@@ -74,7 +76,7 @@ func (cmd *ServeCmd) Run(log *zap.Logger) error {
 		log.Debug("starting SSH server")
 		g.Go(func() error {
 			s := server.NewSSH(log)
-			a := ssh.NewAgent(p, log, cmd.LoadKeyfile, n, cancel)
+			a := ssh.NewAgent(p, pe, log, cmd.LoadKeyfile, n, cancel)
 			err := s.Serve(ctx, a, ls[cmd.AgentTypes["ssh"]], idle, cmd.IdleTimeout)
 			if err != nil {
 				log.Debug("exiting SSH server", zap.Error(err))
@@ -94,7 +96,7 @@ func (cmd *ServeCmd) Run(log *zap.Logger) error {
 	if _, ok := cmd.AgentTypes["gpg"]; ok {
 		log.Debug("starting GPG server")
 		g.Go(func() error {
-			s := server.NewGPG(p, &pinentry.PINEntry{}, log, fallbackKeys, n)
+			s := server.NewGPG(p, pe, log, fallbackKeys, n)
 			err := s.Serve(ctx, ls[cmd.AgentTypes["gpg"]], idle, cmd.IdleTimeout)
 			if err != nil {
 				log.Debug("exiting GPG server", zap.Error(err))

--- a/cmd/piv-agent/setup.go
+++ b/cmd/piv-agent/setup.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strconv"
 
+	"github.com/smlx/piv-agent/internal/pinentry"
 	"github.com/smlx/piv-agent/internal/securitykey"
 	"golang.org/x/crypto/ssh/terminal"
 )
@@ -56,7 +57,7 @@ func (cmd *SetupCmd) Run() error {
 	if cmd.PIN < 100000 || cmd.PIN > 99999999 {
 		return fmt.Errorf("invalid PIN, must be 6-8 digits")
 	}
-	k, err := securitykey.New(cmd.Card)
+	k, err := securitykey.New(cmd.Card, pinentry.New("pinentry"))
 	if err != nil {
 		return fmt.Errorf("couldn't get security key: %v", err)
 	}

--- a/cmd/piv-agent/setupslots.go
+++ b/cmd/piv-agent/setupslots.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/smlx/piv-agent/internal/pinentry"
 	"github.com/smlx/piv-agent/internal/securitykey"
 )
 
@@ -30,7 +31,7 @@ func (cmd *SetupSlotsCmd) Run() error {
 	if cmd.PIN < 100000 || cmd.PIN > 99999999 {
 		return fmt.Errorf("invalid PIN, must be 6-8 digits")
 	}
-	k, err := securitykey.New(cmd.Card)
+	k, err := securitykey.New(cmd.Card, pinentry.New("pinentry"))
 	if err != nil {
 		return fmt.Errorf("couldn't get security key: %v", err)
 	}

--- a/internal/assuan/assuan.go
+++ b/internal/assuan/assuan.go
@@ -1,3 +1,4 @@
+// Package assuan implements an libgcrypt Assuan protocol server.
 package assuan
 
 //go:generate mockgen -source=assuan.go -destination=../mock/mock_assuan.go -package=mock
@@ -13,6 +14,7 @@ import (
 	"strings"
 
 	"github.com/smlx/fsm"
+	"github.com/smlx/piv-agent/internal/notify"
 	"go.uber.org/zap"
 	"golang.org/x/crypto/openpgp/s2k"
 )
@@ -33,10 +35,12 @@ type KeyService interface {
 
 // New initialises a new gpg-agent server assuan FSM.
 // It returns a *fsm.Machine configured in the ready state.
-func New(rw io.ReadWriter, log *zap.Logger, ks ...KeyService) *Assuan {
+func New(rw io.ReadWriter, log *zap.Logger, n *notify.Notify,
+	ks ...KeyService) *Assuan {
 	var signature []byte
 	var keygrips, hash [][]byte
 	assuan := Assuan{
+		notify: n,
 		reader: bufio.NewReader(rw),
 		Machine: fsm.Machine{
 			State:       fsm.State(ready),

--- a/internal/assuan/assuan_test.go
+++ b/internal/assuan/assuan_test.go
@@ -11,12 +11,14 @@ import (
 	"math/big"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/golang/mock/gomock"
 	"github.com/smlx/piv-agent/internal/assuan"
 	"github.com/smlx/piv-agent/internal/keyservice/gpg"
 	"github.com/smlx/piv-agent/internal/mock"
+	"github.com/smlx/piv-agent/internal/notify"
 	"github.com/smlx/piv-agent/internal/securitykey"
 	"go.uber.org/zap"
 	"golang.org/x/crypto/cryptobyte"
@@ -146,7 +148,8 @@ func TestSign(t *testing.T) {
 			if err != nil {
 				tt.Fatal(err)
 			}
-			a := assuan.New(&mockConn, log, keyService)
+			n := notify.New(log, 6*time.Second)
+			a := assuan.New(&mockConn, log, n, keyService)
 			// write all the lines into the statemachine
 			for _, in := range tc.input {
 				if _, err := mockConn.ReadBuf.WriteString(in); err != nil {
@@ -221,7 +224,8 @@ func TestKeyinfo(t *testing.T) {
 			if err != nil {
 				tt.Fatal(err)
 			}
-			a := assuan.New(&mockConn, log, keyService)
+			n := notify.New(log, 6*time.Second)
+			a := assuan.New(&mockConn, log, n, keyService)
 			// write all the lines into the statemachine
 			for _, in := range tc.input {
 				if _, err := mockConn.ReadBuf.WriteString(in); err != nil {
@@ -340,7 +344,8 @@ func TestDecryptRSAKeyfile(t *testing.T) {
 			// mockConn is a pair of buffers that the assuan statemachine reads/write
 			// to/from.
 			mockConn := MockConn{}
-			a := assuan.New(&mockConn, log, gpg.New(log, mockPES, tc.keyPath))
+			n := notify.New(log, 6*time.Second)
+			a := assuan.New(&mockConn, log, n, gpg.New(log, mockPES, tc.keyPath))
 			// write all the lines into the statemachine
 			for _, in := range tc.input {
 				if _, err := mockConn.ReadBuf.WriteString(in); err != nil {
@@ -434,7 +439,8 @@ func TestSignRSAKeyfile(t *testing.T) {
 			// mockConn is a pair of buffers that the assuan statemachine reads/write
 			// to/from.
 			mockConn := MockConn{}
-			a := assuan.New(&mockConn, log, gpg.New(log, mockPES, tc.keyPath))
+			n := notify.New(log, 6*time.Second)
+			a := assuan.New(&mockConn, log, n, gpg.New(log, mockPES, tc.keyPath))
 			// write all the lines into the statemachine
 			for _, in := range tc.input {
 				if _, err := mockConn.ReadBuf.WriteString(in); err != nil {
@@ -516,7 +522,8 @@ func TestReadKey(t *testing.T) {
 			// mockConn is a pair of buffers that the assuan statemachine reads/write
 			// to/from.
 			mockConn := MockConn{}
-			a := assuan.New(&mockConn, log, gpg.New(log, mockPES, tc.keyPath))
+			n := notify.New(log, 6*time.Second)
+			a := assuan.New(&mockConn, log, n, gpg.New(log, mockPES, tc.keyPath))
 			// write all the lines into the statemachine
 			for _, in := range tc.input {
 				if _, err := mockConn.ReadBuf.WriteString(in); err != nil {
@@ -628,7 +635,8 @@ func TestDecryptECDHKeyfile(t *testing.T) {
 			// mockConn is a pair of buffers that the assuan statemachine reads/write
 			// to/from.
 			mockConn := MockConn{}
-			a := assuan.New(&mockConn, log, gpg.New(log, mockPES, tc.keyPath))
+			n := notify.New(log, 6*time.Second)
+			a := assuan.New(&mockConn, log, n, gpg.New(log, mockPES, tc.keyPath))
 			// write all the lines into the statemachine
 			for _, in := range tc.input {
 				if _, err := mockConn.ReadBuf.WriteString(in); err != nil {

--- a/internal/assuan/fsm.go
+++ b/internal/assuan/fsm.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 
 	"github.com/smlx/fsm"
+	"github.com/smlx/piv-agent/internal/notify"
 )
 
 //go:generate enumer -type=Event -text -transform upper
@@ -55,7 +56,8 @@ const (
 // Assuan is the Assuan protocol FSM.
 type Assuan struct {
 	fsm.Machine
-	mu sync.Mutex
+	mu     sync.Mutex
+	notify *notify.Notify
 	// buffered IO for linewise reading
 	reader *bufio.Reader
 	// data is passed during Occur()

--- a/internal/assuan/sign.go
+++ b/internal/assuan/sign.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"math/big"
 
-	"github.com/smlx/piv-agent/internal/notify"
 	"golang.org/x/crypto/cryptobyte"
 	"golang.org/x/crypto/cryptobyte/asn1"
 )
@@ -41,7 +40,7 @@ func (a *Assuan) signRSA() ([]byte, error) {
 // separately s-exp encoded. So we have to decode the ASN1 signature, extract
 // the params, and re-encode them into the s-exp. Ugh.
 func (a *Assuan) signECDSA() ([]byte, error) {
-	cancel := notify.Touch(nil)
+	cancel := a.notify.Touch()
 	defer cancel()
 	signature, err := a.signer.Sign(rand.Reader, a.hash, a.hashAlgo)
 	if err != nil {

--- a/internal/keyservice/piv/keyservice.go
+++ b/internal/keyservice/piv/keyservice.go
@@ -1,3 +1,4 @@
+// Package piv implements the PIV keyservice.
 package piv
 
 import (
@@ -9,6 +10,7 @@ import (
 
 	pivgo "github.com/go-piv/piv-go/piv"
 	"github.com/smlx/piv-agent/internal/keyservice/gpg"
+	"github.com/smlx/piv-agent/internal/pinentry"
 	"go.uber.org/zap"
 )
 
@@ -17,13 +19,15 @@ import (
 type KeyService struct {
 	mu           sync.Mutex
 	log          *zap.Logger
+	pinentry     *pinentry.PINEntry
 	securityKeys []SecurityKey
 }
 
 // New constructs a PIV and returns it.
-func New(l *zap.Logger) *KeyService {
+func New(l *zap.Logger, pe *pinentry.PINEntry) *KeyService {
 	return &KeyService{
-		log: l,
+		log:      l,
+		pinentry: pe,
 	}
 }
 

--- a/internal/keyservice/piv/list.go
+++ b/internal/keyservice/piv/list.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 
 	"github.com/go-piv/piv-go/piv"
+	"github.com/smlx/piv-agent/internal/pinentry"
 	"github.com/smlx/piv-agent/internal/securitykey"
 	"go.uber.org/zap"
 )
@@ -39,7 +40,7 @@ func (p *KeyService) reloadSecurityKeys() error {
 		return fmt.Errorf("couldn't get cards: %v", err)
 	}
 	for _, card := range cards {
-		sk, err := securitykey.New(card)
+		sk, err := securitykey.New(card, pinentry.New("pinentry"))
 		if err != nil {
 			p.log.Warn("couldn't get SecurityKey", zap.String("card", card),
 				zap.Error(err))

--- a/internal/notify/touch.go
+++ b/internal/notify/touch.go
@@ -1,3 +1,4 @@
+// Package notify implements a touch notification system.
 package notify
 
 import (
@@ -8,22 +9,34 @@ import (
 	"go.uber.org/zap"
 )
 
-const waitTime = 6 * time.Second
+// Notify contains touch notification configuration.
+type Notify struct {
+	log              *zap.Logger
+	touchNotifyDelay time.Duration
+}
+
+// New initialises a new Notify struct.
+func New(log *zap.Logger, touchNotifyDelay time.Duration) *Notify {
+	return &Notify{
+		log:              log,
+		touchNotifyDelay: touchNotifyDelay,
+	}
+}
 
 // Touch starts a goroutine, and waits for a short period. If the returned
 // CancelFunc has not been called it sends a notification to remind the user to
 // physically touch the Security Key.
-func Touch(log *zap.Logger) context.CancelFunc {
+func (n *Notify) Touch() context.CancelFunc {
 	ctx, cancel := context.WithCancel(context.Background())
-	timer := time.NewTimer(waitTime)
+	timer := time.NewTimer(n.touchNotifyDelay)
 	go func() {
 		select {
 		case <-ctx.Done():
 			timer.Stop()
 		case <-timer.C:
 			err := beeep.Alert("Security Key Agent", "Waiting for touch...", "")
-			if err != nil && log != nil {
-				log.Warn("couldn't send touch notification", zap.Error(err))
+			if err != nil {
+				n.log.Warn("couldn't send touch notification", zap.Error(err))
 			}
 		}
 	}()

--- a/internal/ssh/agent.go
+++ b/internal/ssh/agent.go
@@ -44,10 +44,10 @@ var ErrUnknownKey = errors.New("requested signature of unknown key")
 var passphrases = map[string][]byte{}
 
 // NewAgent returns a new Agent.
-func NewAgent(p *piv.KeyService, log *zap.Logger, loadKeyfile bool,
-	n *notify.Notify, cancel context.CancelFunc) *Agent {
-	return &Agent{piv: p, log: log, notify: n, loadKeyfile: loadKeyfile,
-		cancel: cancel}
+func NewAgent(p *piv.KeyService, pe *pinentry.PINEntry, log *zap.Logger,
+	loadKeyfile bool, n *notify.Notify, cancel context.CancelFunc) *Agent {
+	return &Agent{piv: p, pinentry: pe, log: log, notify: n,
+		loadKeyfile: loadKeyfile, cancel: cancel}
 }
 
 // List returns the identities known to the agent.

--- a/internal/ssh/agent.go
+++ b/internal/ssh/agent.go
@@ -1,3 +1,4 @@
+// Package ssh implements an ssh-agent.
 package ssh
 
 import (
@@ -27,6 +28,7 @@ type Agent struct {
 	mu          sync.Mutex
 	piv         *piv.KeyService
 	log         *zap.Logger
+	notify      *notify.Notify
 	pinentry    *pinentry.PINEntry
 	loadKeyfile bool
 	cancel      context.CancelFunc
@@ -42,9 +44,10 @@ var ErrUnknownKey = errors.New("requested signature of unknown key")
 var passphrases = map[string][]byte{}
 
 // NewAgent returns a new Agent.
-func NewAgent(p *piv.KeyService, log *zap.Logger,
-	loadKeyfile bool, cancel context.CancelFunc) *Agent {
-	return &Agent{piv: p, log: log, loadKeyfile: loadKeyfile, cancel: cancel}
+func NewAgent(p *piv.KeyService, log *zap.Logger, loadKeyfile bool,
+	n *notify.Notify, cancel context.CancelFunc) *Agent {
+	return &Agent{piv: p, log: log, notify: n, loadKeyfile: loadKeyfile,
+		cancel: cancel}
 }
 
 // List returns the identities known to the agent.
@@ -140,13 +143,13 @@ func (a *Agent) Sign(key gossh.PublicKey, data []byte) (*gossh.Signature, error)
 	return a.signWithSigners(key, data, ks)
 }
 
-func (a *Agent) signWithSigners(key gossh.PublicKey, data []byte, signers []gossh.Signer) (*gossh.Signature, error) {
+func (a *Agent) signWithSigners(key gossh.PublicKey, data []byte,
+	signers []gossh.Signer) (*gossh.Signature, error) {
 	for _, s := range signers {
 		if !bytes.Equal(s.PublicKey().Marshal(), key.Marshal()) {
 			continue
 		}
-		// (possibly) send a notification
-		cancel := notify.Touch(a.log)
+		cancel := a.notify.Touch()
 		defer cancel()
 		// perform signature
 		a.log.Debug("signing",


### PR DESCRIPTION
This change adds the following configuration options to `piv-agent serve`:

*  `--touch-notify-delay` allows configuration of the delay before `piv-agent` will notify when waiting for a touch. It defaults to `6s`.
* `--pinentry-binary-name` allows configuration of the PIN entry command which will be called by `piv-agent`. This is useful for platforms without something similar to the Debian alternatives system. It defaults to `pinentry`.

Closes: #133 