### PR TITLE
chore: use the new syntax for output variables in github actions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,7 +31,7 @@ jobs:
         if [ -z $(git tag -l $(ccv)) ]; then
           git tag $(ccv)
           git push --tags
-          echo "::set-output name=new::true"
+          echo "new=true" >> $GITHUB_OUTPUT
         fi
   release:
     needs: tag


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

<!--
IMPORTANT NOTE: Commits must adhere to the conventional commits specification:
https://www.conventionalcommits.org/en/v1.0.0/

Explain the **details** for making this change. What existing problem does the pull request solve?

Put `Closes: #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
-->
