### PR TITLE
chore: Add release support for Apple Silicon

### DIFF
--- a/.goreleaser.macos-latest.yml
+++ b/.goreleaser.macos-latest.yml
@@ -9,6 +9,7 @@ builds:
   - darwin
   goarch:
   - amd64
+  - arm64
   ldflags:
   - >
     -s -w -X main.date={{.Date}} -X "main.goVersion={{.Env.GOVERSION}}"


### PR DESCRIPTION
Add `goarch:arm64` build param to the macOS goreleaser configuration.

This avoids the need for [Rosetta](https://developer.apple.com/documentation/apple-silicon/about-the-rosetta-translation-environment) on M1 and M2 chipsets.
