### PR TITLE
fix: correctly convert to openpgp ecdsa key representation

### DIFF
--- a/internal/keyservice/gpg/keyservice.go
+++ b/internal/keyservice/gpg/keyservice.go
@@ -6,7 +6,6 @@ import (
 	"bytes"
 	"crypto"
 	"crypto/ecdsa"
-	"crypto/elliptic"
 	"crypto/rsa"
 	"fmt"
 
@@ -135,48 +134,6 @@ func (g *KeyService) getRSAKey(keygrip []byte) (*rsa.PrivateKey, error) {
 		}
 	}
 	return nil, nil
-}
-
-func nameToCurve(name string) (elliptic.Curve, error) {
-	switch name {
-	case elliptic.P224().Params().Name:
-		return elliptic.P224(), nil
-	case elliptic.P256().Params().Name:
-		return elliptic.P256(), nil
-	case elliptic.P384().Params().Name:
-		return elliptic.P384(), nil
-	case elliptic.P521().Params().Name:
-		return elliptic.P521(), nil
-	default:
-		return nil, fmt.Errorf("unknown curve name: %s", name)
-	}
-}
-
-func ecdsaPublicKey(k *openpgpecdsa.PublicKey) (*ecdsa.PublicKey, error) {
-	curve, err := nameToCurve(k.GetCurve().GetCurveName())
-	if err != nil {
-		return nil, err
-	}
-	return &ecdsa.PublicKey{
-		Curve: curve,
-		X:     k.X,
-		Y:     k.Y,
-	}, nil
-}
-
-func ecdsaPrivateKey(k *openpgpecdsa.PrivateKey) (*ecdsa.PrivateKey, error) {
-	curve, err := nameToCurve(k.GetCurve().GetCurveName())
-	if err != nil {
-		return nil, err
-	}
-	return &ecdsa.PrivateKey{
-		D: k.D,
-		PublicKey: ecdsa.PublicKey{
-			Curve: curve,
-			X:     k.X,
-			Y:     k.Y,
-		},
-	}, nil
 }
 
 // getECDSAKey returns a matching private ECDSA key if the keygrip matches. If

--- a/internal/keyservice/gpg/openpgpecdsa.go
+++ b/internal/keyservice/gpg/openpgpecdsa.go
@@ -1,0 +1,57 @@
+package gpg
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"fmt"
+
+	openpgpecdsa "github.com/ProtonMail/go-crypto/openpgp/ecdsa"
+)
+
+// nameToCurve takes a given curve name and returns the associated
+// elliptic.Curve.
+func nameToCurve(name string) (elliptic.Curve, error) {
+	switch name {
+	case elliptic.P224().Params().Name:
+		return elliptic.P224(), nil
+	case elliptic.P256().Params().Name:
+		return elliptic.P256(), nil
+	case elliptic.P384().Params().Name:
+		return elliptic.P384(), nil
+	case elliptic.P521().Params().Name:
+		return elliptic.P521(), nil
+	default:
+		return nil, fmt.Errorf("unknown curve name: %s", name)
+	}
+}
+
+// ecdsaPublicKey converts the given ECDSA Key in go-crypto/openpgp
+// representation, to standard library crypto/ecdsa representation.
+func ecdsaPublicKey(k *openpgpecdsa.PublicKey) (*ecdsa.PublicKey, error) {
+	curve, err := nameToCurve(k.GetCurve().GetCurveName())
+	if err != nil {
+		return nil, err
+	}
+	return &ecdsa.PublicKey{
+		Curve: curve,
+		X:     k.X,
+		Y:     k.Y,
+	}, nil
+}
+
+// ecdsaPrivateKey converts the given ECDSA Key in go-crypto/openpgp
+// representation, to standard library crypto/ecdsa representation.
+func ecdsaPrivateKey(k *openpgpecdsa.PrivateKey) (*ecdsa.PrivateKey, error) {
+	curve, err := nameToCurve(k.GetCurve().GetCurveName())
+	if err != nil {
+		return nil, err
+	}
+	return &ecdsa.PrivateKey{
+		D: k.D,
+		PublicKey: ecdsa.PublicKey{
+			Curve: curve,
+			X:     k.X,
+			Y:     k.Y,
+		},
+	}, nil
+}

--- a/internal/securitykey/decryptingkey.go
+++ b/internal/securitykey/decryptingkey.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 
-	openpgpecdsa "github.com/ProtonMail/go-crypto/openpgp/ecdsa"
 	"github.com/ProtonMail/go-crypto/openpgp/packet"
 	"github.com/go-piv/piv-go/piv"
 )
@@ -39,7 +38,7 @@ func decryptingKeys(yk *piv.YubiKey) ([]DecryptingKey, error) {
 				SlotSpec: s,
 			},
 			PubPGP: packet.NewECDSAPublicKey(cert.NotBefore,
-				openpgpecdsa.NewPublicKeyFromCurve(pubKey.Curve)),
+				openpgpECDSAPublicKey(pubKey)),
 		})
 	}
 	return decryptingKeys, nil

--- a/internal/securitykey/openpgpecdsa.go
+++ b/internal/securitykey/openpgpecdsa.go
@@ -1,0 +1,16 @@
+package securitykey
+
+import (
+	"crypto/ecdsa"
+
+	openpgpecdsa "github.com/ProtonMail/go-crypto/openpgp/ecdsa"
+)
+
+// openpgpECDSAPublicKey converts the given ECDSA Key in crypto/ecdsa
+// representation, to go-crypto/openpgp representation.
+func openpgpECDSAPublicKey(k *ecdsa.PublicKey) *openpgpecdsa.PublicKey {
+	openpgpPubKey := openpgpecdsa.NewPublicKeyFromCurve(k.Curve)
+	openpgpPubKey.X = k.X
+	openpgpPubKey.Y = k.Y
+	return openpgpPubKey
+}

--- a/internal/securitykey/signingkey.go
+++ b/internal/securitykey/signingkey.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 
-	openpgpecdsa "github.com/ProtonMail/go-crypto/openpgp/ecdsa"
 	"github.com/ProtonMail/go-crypto/openpgp/packet"
 	"github.com/go-piv/piv-go/piv"
 	"golang.org/x/crypto/ssh"
@@ -45,7 +44,7 @@ func signingKeys(yk *piv.YubiKey) ([]SigningKey, error) {
 			},
 			PubSSH: pubSSH,
 			PubPGP: packet.NewECDSAPublicKey(cert.NotBefore,
-				openpgpecdsa.NewPublicKeyFromCurve(pubKey.Curve)),
+				openpgpECDSAPublicKey(pubKey)),
 		})
 	}
 	return signingKeys, nil


### PR DESCRIPTION
This change corrects the conversion from standard library ECDSA public key representation to go-crypto/openpgp representation.