### PR TITLE
feat: modernise build

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -18,9 +18,7 @@ jobs:
       run: sudo apt-get update && sudo apt-get -u install libpcsclite-dev
     - name: Calculate coverage
       run: |
-        go test -v -covermode=atomic -coverprofile=cover.out.raw -coverpkg=./... ./...
-        # remove generated code from coverage calculation
-        grep -Ev 'internal/mock|_enumer.go' cover.out.raw > cover.out
+        go test -count=1 -v -covermode=atomic -coverprofile=cover.out -coverpkg=./... ./...
     - name: Generage coverage badge
       uses: vladopajic/go-test-coverage@679e6807f68f2440a4c43d386442a1d0041838a9 # v2.18.3
       with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -38,23 +38,15 @@ jobs:
         go-version: stable
     - name: Install Dependencies
       run: sudo apt-get update && sudo apt-get -u install libpcsclite-dev
-    - uses: advanced-security/sbom-generator-action@6fe43abf522b2e7a19bc769aec1e6c848614b517 # v0.0.2
-      id: sbom
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    - name: Move sbom to avoid dirty git
-      run: mv "$GITHUB_SBOM_PATH" ./sbom.spdx.json
-      env:
-        GITHUB_SBOM_PATH: ${{ steps.sbom.outputs.fileName }}
-    - uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7.2.2
+    - uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+    - uses: goreleaser/goreleaser-action@1a80836c5c9d9e5755a25cb59ec6f45a3b5f41a8 # v7.2.1
       id: goreleaser
       with:
         version: latest
-        args: release --clean --config .goreleaser.yaml
+        args: release --verbose
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        GITHUB_SBOM_PATH: ./sbom.spdx.json
-    # attest archives
-    - uses: actions/attest-build-provenance@96278af6caaf10aea03fd8d33a09a777ca52d62f # v3.2.0
+    # attest artifacts
+    - uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
       with:
-        subject-path: "dist/*.tar.gz"
+        subject-checksums: ./dist/checksums.txt


### PR DESCRIPTION
The v1.0.0 tag failed to build due to a broken release workflow :see_no_evil: 

This change fixes the build.